### PR TITLE
Footer logos styled in black and paragraph under EU-logo

### DIFF
--- a/app/packs/stylesheets/recharge/_footer.scss
+++ b/app/packs/stylesheets/recharge/_footer.scss
@@ -28,6 +28,10 @@
         width: 15rem;
       }
     }
+    p {
+      font-size: 0.5rem;
+      margin-bottom: 0;
+    }
   }
   .row {
     display: flex;
@@ -59,4 +63,8 @@
   span {
     color: #404040;
   }
+}
+
+.decidim-logo img {
+  filter: brightness(0);
 }

--- a/app/views/recharge/_eu_footer.html.erb
+++ b/app/views/recharge/_eu_footer.html.erb
@@ -7,6 +7,7 @@
         </div>
         <div class="eu-disclaimer__img">
           <%= image_pack_tag "media/images/EN-Funded_by_the_EU-BLACK.png", class: "flag", alt: "European Union flag: Funded by the European Union" %>
+          <p>Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union or the European Research Executive Agency. Neither the European Union nor the granting authority can be held responsible for them.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
New style for the footer logos.

Both of decidim and platoniq logos are styled in black.
EU-logo got a paragraph below